### PR TITLE
Add type and type alias kinds, and small other fixes

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -3,3 +3,5 @@
 --regex-Elm=/^ *([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:].*->.*/\1/f,function,functions/
 --regex-Elm=/^ *([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:][^-]+$/\1/c,constant,constants/
 --regex-Elm=/^port +([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:]/\1/p,port,ports/
+--regex-Elm=/^type +([[:upper:]][[:alnum:]_]+)/\1/t,type,types/
+--regex-Elm=/^type[[:blank:]]+alias[[:blank:]]+([[:upper:]][[:alnum:]_]+)/\1/a,type-alias,type-aliases/

--- a/.ctags
+++ b/.ctags
@@ -1,5 +1,5 @@
 --langdef=Elm
 --langmap=Elm:.elm
---regex-Elm=/^ *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:].*->.*/\1/f,function,functions/
---regex-Elm=/^ *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:][^-]+$/\1/c,constant,constants/
---regex-Elm=/^port *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:]/\1/p,port,ports/
+--regex-Elm=/^ *([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:].*->.*/\1/f,function,functions/
+--regex-Elm=/^ *([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:][^-]+$/\1/c,constant,constants/
+--regex-Elm=/^port +([[:lower:]][[:alnum:]_]+)[[:blank:]]*:[^:]/\1/p,port,ports/

--- a/.ctags
+++ b/.ctags
@@ -1,5 +1,5 @@
 --langdef=Elm
 --langmap=Elm:.elm
---regex-Elm=/^ *([a-z][a-zA-Z0-9_-]+)[ \t]*:[^:].*->.*/\1/f,function,functions/
---regex-Elm=/^ *([a-z][a-zA-Z0-9_-]+)[ \t]*:[^:][^-]+$/\1/c,constant,constants/
---regex-Elm=/^port *([a-z][a-zA-Z0-9_-]+)[ \t]*:[^:]/\1/p,port,ports/
+--regex-Elm=/^ *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:].*->.*/\1/f,function,functions/
+--regex-Elm=/^ *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:][^-]+$/\1/c,constant,constants/
+--regex-Elm=/^port *([[:lower:]][[:alnum:]_-]+)[[:blank:]]*:[^:]/\1/p,port,ports/


### PR DESCRIPTION
- I switched to [posix style character classes](https://en.wikipedia.org/wiki/Regular_expression#Character_classes) (`[:blank:]`, etc.) because I saw them in the example ctags regexes I was looking at today (never seen them before). I think they make regexes easier to understand.

- I removed `-` from identifiers because when I tried to make identifiers with hyphens in, elm-make complained. I'm not adding single quotes as they just removed support for primed named in 0.18

- There's at leas one space required after `port` now

- I added `type` and `type alias` kinds

I separated the commits but it's one PR because its only a handfull of lines.